### PR TITLE
Automatic Nightly building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: lua
+sudo: required
+
+before_script:
+  - sudo apt-get install libstdc++6
+  - chmod +x travis-autobuild.sh
+  - chmod +x buildtools/linux/*
+
+script:
+  - make tarzip
+
+after_script:
+  - ./travis-autobuild.sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Just run `make` (or `make all`/`make build`) to get your binaries in the build d
 `build 3ds`, `build 3dsx` and `build cia` are also available in case not all binaries need to be built.
 
 You can also use `make clean` to remove all built files.
+## Nightlies
+Nightlies are available at [the official automatic Nightly build page](https://hikiruka.github.io/Yuki-FM/build/) and build whenever changes get pushed to the `master` branch
 
 
 ## Credits

--- a/travis-autobuild.sh
+++ b/travis-autobuild.sh
@@ -15,7 +15,7 @@ function createBuildPage {
 	GH_REPOSITORY=${GH_REPO_ARR[1]}
 	shopt -s nullglob
 	for f in *.3ds *.3dsx *.cia *.tar *.gz *.zip; do
-		echo -e "| [$f](https://$GH_REPO_USER.github.io/$GH_REPOSITORY/build/$f) | `du -h $f | cut -f1` |" >> index.md
+		echo -e "| [$f](https://$GH_REPO_USER.github.io/$GH_REPOSITORY/build/$f) | `du -h "$f" | cut -f1` |" >> index.md
 	done
 	cd ..
 	echo -e "\nQR Code for Homebr3w.cia Build:<br>![QR Code](https://$GH_REPO_USER.github.io/$GH_REPOSITORY/build/QRCode.jpg)" >> build/index.md

--- a/travis-autobuild.sh
+++ b/travis-autobuild.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+function createBuildPage {
+	echo -e "Building build page"
+	echo -e "---\ntitle: $GH_REPO Nightlies\n---" > build/index.md
+	echo -e "# Automatic Build System for [$GH_REPO](https://github.com/$GH_REPO) Nightlies\n\nNightly builds are generated automatically through [Travis-CI](https://travis-ci.org/) whenever a new commit is pushed on \`$GH_CI_BRANCH\`.\n" >> build/index.md
+	echo -e "## Warning: These builds may be unstable and may contain bugs. If you use these builds and find any problems, please open a new Issue at [https://github.com/$GH_REPO/issues](https://github.com/$GH_REPO/issues)\n" >> build/index.md
+	echo -e "Latest commit: [#`echo $TRAVIS_COMMIT | cut -c 1-7`](https://github.com/$GH_REPO/commit/$TRAVIS_COMMIT)<br>" >> build/index.md
+	echo -e "Build date: `date`\n" >> build/index.md
+	echo -e "| Download Link | File Size |\n|---------------|-----------|" >> build/index.md
+	cd build
+	GH_REPO_ARR=(${GH_REPO//\//\ })
+	GH_REPO_USER=${GH_REPO_ARR[0]}
+	GH_REPOSITORY=${GH_REPO_ARR[1]}
+	shopt -s nullglob
+	for f in *.3ds *.3dsx *.cia *.tar *.gz *.zip; do
+		echo -e "| [$f](https://$GH_REPO_USER.github.io/$GH_REPOSITORY/build/$f) | `du -h $f | cut -f1` |" >> index.md
+	done
+	cd ..
+	echo -e "\nQR Code for Homebr3w.cia Build:<br>![QR Code](https://$GH_REPO_USER.github.io/$GH_REPOSITORY/build/QRCode.jpg)" >> build/index.md
+}
+
+if [ "$TRAVIS_REPO_SLUG" == "$GH_REPO" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "$GH_CI_BRANCH" ]; then
+  echo -e "Trying to push new commit to gh_pages\n"
+
+  git config --global user.email "travis@travis-ci.org" || true
+  git config --global user.name "travis-ci" || true
+  git remote set-branches --add origin gh-pages
+  git fetch
+  git checkout -f -t -b gh-pages origin/gh-pages
+  git merge --no-commit --no-ff $GH_CI_BRANCH -m "Merge $GH_CI_BRANCH $TRAVIS_COMMIT"
+  git reset
+  chmod +x buildtools/linux/*
+  make tarzip
+  git add -f build
+  git diff --staged --quiet build || {
+	createBuildPage
+	git add -f build/index.md
+    git commit -m "Pushing build based on commit $TRAVIS_COMMIT"
+	git push -fq https://"$GH_TOKEN"@github.com/"$GH_REPO" gh-pages > /dev/null
+	echo -e "Pushed new build to gh_pages.\n"
+	exit 0
+  }
+  echo -e "Nothing to commit."
+fi


### PR DESCRIPTION
Followup to #2: Make Travis automatically create Nightly versions of pushed commits
Example: https://wolvan.github.io/LuaExplorer/build/

If nightly building is not desired, this PR can be ignored.
Turning off nightly building afterwards is as easy as changing the value of `GH_CI_BRANCH`

**Steps to do before merging this pull request:**
1. Go to https://github.com/Hikiruka/Yuki-FM/generated_pages/new and create a Github.io page for Yuki-FM (You can simply load the readme for example)
2. Activate the Yuki-FM repository on [travis-ci](https://travis-ci.org/)
3. Set the following settings on https://travis-ci.org/Hikiruka/Yuki-FM/settings (replace with your own values of course):
![image](https://cloud.githubusercontent.com/assets/1437010/17968953/086ee03a-6ad0-11e6-88e7-6f0f442e6431.png)
An access token can be created [here](https://github.com/settings/tokens). The access token needs the `repo` scope
![image](https://cloud.githubusercontent.com/assets/1437010/17969030/5fcba390-6ad0-11e6-8691-1cde43b441b6.png)
4. Merge this commit. This should trigger Travis to immediately create the first build page
5. Optional: Check out the gh-pages branch, create a QR Code to the file `https://hikiruka.github.io/Yuki-FM/build/Yuki%20FM.cia`, and check the file into `/build/QRCode.jpg` of the branch `gh-pages`

If there are any questions, I'd be glad to answer them.